### PR TITLE
Fix negative coords

### DIFF
--- a/src/main/kotlin/sexy/kostya/enodia/provider/mutable/MutableBlockStateProvider.kt
+++ b/src/main/kotlin/sexy/kostya/enodia/provider/mutable/MutableBlockStateProvider.kt
@@ -5,7 +5,6 @@ import net.minestom.server.event.EventNode
 import net.minestom.server.event.player.PlayerBlockBreakEvent
 import net.minestom.server.event.player.PlayerBlockPlaceEvent
 import net.minestom.server.event.trait.InstanceEvent
-import net.minestom.server.instance.Chunk
 import net.minestom.server.instance.Instance
 import net.minestom.server.instance.block.Block
 import net.minestom.server.utils.chunk.ChunkUtils
@@ -54,7 +53,7 @@ class MutableBlockStateProvider(instance: Instance) : CachedBlockStateProvider(i
         }
         section[
                 x and 15,
-                y % Chunk.CHUNK_SECTION_SIZE,
+                y and 15,
                 z and 15
         ] = BlockStateProvider.createMaskFromBlock(block)
 

--- a/src/main/kotlin/sexy/kostya/enodia/provider/mutable/MutableBlockStateProvider.kt
+++ b/src/main/kotlin/sexy/kostya/enodia/provider/mutable/MutableBlockStateProvider.kt
@@ -53,9 +53,9 @@ class MutableBlockStateProvider(instance: Instance) : CachedBlockStateProvider(i
             sections[sectionIndex] = section
         }
         section[
-                x % Chunk.CHUNK_SIZE_X,
+                x and 15,
                 y % Chunk.CHUNK_SECTION_SIZE,
-                z % Chunk.CHUNK_SIZE_Z
+                z and 15
         ] = BlockStateProvider.createMaskFromBlock(block)
 
         val copiedCache = Long2ObjectOpenHashMap(cache)


### PR DESCRIPTION
Provider for mutable worlds have problems with placing and destroying blocks in negative x / z.
Example exception: `java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 1536`